### PR TITLE
Changed subMonth source

### DIFF
--- a/kfbot-refactor-phase2/src/main/java/com/twitchbotx/bot/CommandParser.java
+++ b/kfbot-refactor-phase2/src/main/java/com/twitchbotx/bot/CommandParser.java
@@ -833,7 +833,7 @@ public class CommandParser {
                 gifted = false;
             } else {
                 // sub gift notification does not have this param
-                int beginMonths = msg.indexOf("msg-param-months=") + 17;
+                int beginMonths = msg.indexOf("msg-param-cumulative-months=") + 28;
                 int endMonths = msg.indexOf(";", beginMonths);
                 subMonths = msg.substring(beginMonths, endMonths);
                 massGifted = false;


### PR DESCRIPTION
Removed deprecated use of "msg-param-sub-months" 
Changed to "msg-param-cumulative-months" 